### PR TITLE
Fix Null Pointer Issues-8

### DIFF
--- a/android-smsmms/src/main/java/com/android/mms/transaction/Transaction.java
+++ b/android-smsmms/src/main/java/com/android/mms/transaction/Transaction.java
@@ -86,7 +86,26 @@ public abstract class Transaction extends Observable {
      * @return true if transaction is equivalent to this instance, false otherwise.
      */
     public boolean isEquivalent(Transaction transaction) {
-        return mId.equals(transaction.mId);
+        
+		/* ********OpenRefactory Warning********
+		 Possible null pointer dereference!
+		 Path: 
+			File: TransactionService.java, Line: 697
+				processTransaction(transaction)
+				 Information is passed through the method call via transaction to the formal param transaction of the method. This later results into a null pointer dereference.
+				The expression is enclosed inside an If statement.
+			File: TransactionService.java, Line: 811
+				Transaction transaction
+				Variable transaction is declared as a formal parameter.
+			File: TransactionService.java, Line: 821
+				t.isEquivalent(transaction)
+				 Information is passed through the method call via transaction to the formal param transaction of the method. This later results into a null pointer dereference.
+				The expression is enclosed inside an If statement.
+			File: Transaction.java, Line: 89
+				return mId.equals(transaction.mId);
+				transaction is referenced in field access.
+		*/
+		return mId.equals(transaction.mId);
     }
 
     /**


### PR DESCRIPTION
In file: Transaction.java, class: Transaction, there is a method isEquivalent that there is a potential Null pointer dereference. This may throw an unexpected null pointer exception which, if unhandled, may crash the program. I detected the null pointer issue and demonstrated the full path from the object declaration to the null dereference in the object. A developer should introduce null checks in the appropriate path or initialize the object explicitly. 