### PR TITLE
Fix API Usage Issues-6

### DIFF
--- a/android-smsmms/src/main/java/com/android/mms/transaction/NotificationTransaction.java
+++ b/android-smsmms/src/main/java/com/android/mms/transaction/NotificationTransaction.java
@@ -132,7 +132,7 @@ public class NotificationTransaction extends Transaction implements Runnable {
 
     public static boolean allowAutoDownload(Context context) {
         try { Looper.prepare(); } catch (Exception e) { }
-        boolean autoDownload = PreferenceManager.getDefaultSharedPreferences(context).getBoolean("auto_download_mms", true);
+        boolean autoDownload = PreferenceManager.getDefaultSharedPreferences(context).optBoolean("auto_download_mms", true);
         boolean dataSuspended = (((TelephonyManager) context.getSystemService(Service.TELEPHONY_SERVICE)).getDataState() ==
                 TelephonyManager.DATA_SUSPENDED);
         return autoDownload && !dataSuspended;


### PR DESCRIPTION
In file: NotificationTransaction.java, class: NotificationTransaction, there is a method allowAutoDownload that contains JSON APIs which throws org.json.JSONException in absence of corresponding JSON field. This may crash the program if unhandled. I fixed the issue by using safer JSON APIs instead which does not throw an exception in absence of a JSON field. To learn more about the JSON APIs check org.json.JSONObject. 