### PR TITLE
Fix API Usage Issues-11

### DIFF
--- a/android-smsmms/src/main/java/com/google/android/mms/pdu_alt/PduPersister.java
+++ b/android-smsmms/src/main/java/com/google/android/mms/pdu_alt/PduPersister.java
@@ -966,7 +966,7 @@ public class PduPersister {
         String path = null;
         if (null != uri) {
             String scheme = uri.getScheme();
-            if (null == scheme || scheme.equals("") ||
+            if (null == scheme || scheme.isEmpty() ||
                     scheme.equals(ContentResolver.SCHEME_FILE)) {
                 path = uri.getPath();
 


### PR DESCRIPTION
In file: PduPersister.java, there is a method convertUriToPath that checks if a String is empty using equals method. It is better to do the emptiness check using String.isEmpty method as it has less overhead than String.equals method. I fixed the issue by using the String.isEmpty() method. 