### PR TITLE
Fix Null Pointer Issues-19

### DIFF
--- a/android-smsmms/src/main/java/com/google/android/mms/pdu_alt/PduParser.java
+++ b/android-smsmms/src/main/java/com/google/android/mms/pdu_alt/PduParser.java
@@ -190,7 +190,18 @@ public class PduParser {
                     // or "application/vnd.wap.multipart.alternative"
                     return retrieveConf;
                 } else if (ctTypeStr.equals(ContentType.MULTIPART_ALTERNATIVE)) {
-                    // "application/vnd.wap.multipart.alternative"
+                    
+					/* ******** Warning********
+					 Possible null pointer dereference!
+					 Path: 
+						File: PushReceiver.java, Line: 87
+							GenericPdu pdu=parser.parse();
+							 Information about field mBody (from class PduParser) is passed through the method call. This later results into a null pointer dereference
+						File: PduParser.java, Line: 195
+							PduPart firstPart=mBody.getPart(0);
+							mBody is referenced in method invocation.
+					*/
+					// "application/vnd.wap.multipart.alternative"
                     // should take only the first part.
                     PduPart firstPart = mBody.getPart(0);
                     mBody.removeAll();


### PR DESCRIPTION
In file: PduParser.java, class: PduParser, there is a method parse that there is a potential Null pointer dereference. This may throw an unexpected null pointer exception which, if unhandled, may crash the program. I detected the null pointer issue and demonstrated the full path from the object declaration to the null dereference in the object. A developer should introduce null checks in the appropriate path or initialize the object explicitly. 