### PR TITLE
Fix Null Pointer Issues-21

### DIFF
--- a/android-smsmms/src/main/java/com/android/mms/service_alt/PhoneUtils.java
+++ b/android-smsmms/src/main/java/com/android/mms/service_alt/PhoneUtils.java
@@ -48,7 +48,17 @@ public class PhoneUtils {
         if (parsed == null) {
             return phoneText;
         }
-        return phoneNumberUtil
+        /* ********OpenRefactory Warning********
+		 Possible null pointer dereference!
+		 Path: 
+			File: MmsConfig.java, Line: 569
+				return PhoneUtils.getNationalNumber(telephonyManager,subId,getLine1(context,subId));
+				 Information is passed through the method call that later results into a null pointer dereference.
+			File: PhoneUtils.java, Line: 51
+				return phoneNumberUtil.format(parsed,PhoneNumberUtil.PhoneNumberFormat.NATIONAL).replaceAll("\\D","");
+				Method format may return null and is referenced in method invocation.
+		*/
+		return phoneNumberUtil
                 .format(parsed, PhoneNumberUtil.PhoneNumberFormat.NATIONAL)
                 .replaceAll("\\D", "");
     }


### PR DESCRIPTION
In file: PhoneUtils.java, class: PhoneUtils, there is a method getNationalNumber that there is a potential Null pointer dereference. This may throw an unexpected null pointer exception which, if unhandled, may crash the program. I detected the null pointer issue and demonstrated the full path from the object declaration to the null dereference in the object. A developer should introduce null checks in the appropriate path or initialize the object explicitly. 